### PR TITLE
feat: support renaming inputs and data files accessed via s3/datashim

### DIFF
--- a/apis/models/common.py
+++ b/apis/models/common.py
@@ -125,13 +125,18 @@ class OptionFromS3Values(Digestable):
     bucket: Optional[str]
     endpoint: Optional[str]
     path: Optional[str]
+    rename: Optional[str] = pydantic.Field(
+        None, description="If set, and path is not None then this means that the path filename should be renamed "
+                          "to match @rename")
     region: Optional[str]
 
 
 class OptionFromDatasetRef(Digestable):
     name: str
     path: Optional[str]
-
+    rename: Optional[str] = pydantic.Field(
+        None, description="If set, and path is not None then this means that the path filename should be renamed "
+                          "to match @rename")
 
 class OptionFromUsernamePassword(Digestable):
     username: Optional[str]

--- a/apis/models/errors.py
+++ b/apis/models/errors.py
@@ -105,6 +105,16 @@ class OverrideVariableError(ApiError):
         super(OverrideVariableError, self).__init__(msg)
 
 
+class InvalidPayloadError(ApiError):
+    def __init__(self, msg: str):
+        super(InvalidPayloadError, self).__init__(msg)
+
+
+class InvalidPayloadExperimentStartError(ApiError):
+    def __init__(self, msg: str):
+        super(InvalidPayloadExperimentStartError, self).__init__(msg)
+
+
 class OverrideDataFilesError(ApiError):
     def __init__(self, names: List[str], msg: str):
         self.names = names

--- a/apis/models/models.py
+++ b/apis/models/models.py
@@ -339,10 +339,22 @@ mPackageHistory = api_experiments.model("package-history", {
 })
 
 mFileContent = api_experiments.model('file-content', {
-    'filename': fields.String(required=True, description='Filename', example="field.conf"),
-    'content': fields.String(required=True, description='Content of file', example='mole:capb,slampd,smlta '
-                                                                                   'conc:4.2,1.4,0.5 '
-                                                                                   'salt:2.8')
+    'filename': fields.String(
+        required=False,
+        description='Filename. Mutually exclusive with sourceFilename and targetFilename', example="field.conf"),
+    'sourceFilename': fields.String(
+        required=False,
+        description="path to the filename. Mutually exclusive with filename and content. "
+                    "If set, must also provide sourceFilename"),
+    'targetFilename': fields.String(
+        required=False,
+        description="How to rename sourceFilename. Mutually exclusive with filename and content. "
+                    "If set, must also provide targetFilename"),
+    'content': fields.String(
+        required=False, description='Content of file. Mutually exclusive with sourceFilename and targetFilename',
+        example="""mole:capb,slampd,smlta
+conc:4.2,1.4,0.5
+salt:2.8""")
 })
 
 # mDataContent = api_experiments.model('data-content', {

--- a/apis/runtime/package.py
+++ b/apis/runtime/package.py
@@ -821,6 +821,10 @@ class NamedPackage:
             if path.startswith(os.path.sep):
                 # VV: joining ("hello" with "/hi there") produces "/hi there"
                 path = path[1:]
+
+            if value.rename:
+                path = ':'.join((path, value.rename))
+
             return os.path.join(ROOT_S3_FILES, file_type, path)
         else:
             raise NotImplementedError(f"Cannot construct filename of data {x.dict()}")

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -45,24 +45,6 @@ paths:
       tags:
         - datasets
   /experiments/:
-    post:
-      responses:
-        '200':
-          description: OK
-        '400':
-          description: Experiment ID is invalid
-        '409':
-          description: Experiment ID already exists
-      summary: Add an experiment
-      operationId: post_experiment_list
-      parameters:
-        - name: payload
-          required: true
-          in: body
-          schema:
-            $ref: '#/definitions/virtual-experiment'
-      tags:
-        - experiments
     get:
       responses:
         '200':
@@ -105,6 +87,24 @@ paths:
             - 'n'
       tags:
         - experiments
+    post:
+      responses:
+        '200':
+          description: OK
+        '400':
+          description: Experiment ID is invalid
+        '409':
+          description: Experiment ID already exists
+      summary: Add an experiment
+      operationId: post_experiment_list
+      parameters:
+        - name: payload
+          required: true
+          in: body
+          schema:
+            $ref: '#/definitions/virtual-experiment'
+      tags:
+        - experiments
   /experiments/lambda/start:
     post:
       responses:
@@ -131,18 +131,6 @@ paths:
         name: identifier
         required: true
         type: string
-    delete:
-      responses:
-        '200':
-          description: Success
-        '404':
-          description: Unknown experiment
-        '500':
-          description: Internal error
-      summary: Delete an experiment
-      operationId: delete_experiment
-      tags:
-        - experiments
     get:
       responses:
         '404':
@@ -183,6 +171,18 @@ paths:
           enum:
             - 'y'
             - 'n'
+      tags:
+        - experiments
+    delete:
+      responses:
+        '200':
+          description: Success
+        '404':
+          description: Unknown experiment
+        '500':
+          description: Internal error
+      summary: Delete an experiment
+      operationId: delete_experiment
       tags:
         - experiments
   /experiments/{identifier}/start:
@@ -282,6 +282,61 @@ paths:
         name: id
         required: true
         type: string
+    put:
+      responses:
+        '200':
+          description: Success
+        '404':
+          description: imagePullSecret not found
+        '500':
+          description: Internal error while retrieving imagePullSecret details
+      summary: Update an existing imagePullSecret
+      description: |-
+        This method does not check whether the contents of the Secret object are correct. In the remainder of this
+        text @configuration IS the contents of the `config.json` key of the `consumable-computing-config` ConfigMap
+        (or the ConfigMap object that the environment variable `CONSUMABLE_COMPUTING_CONFIGMAP_NAME` points to)
+
+        if imagePullSecret is already defined in in the @configuration this method returns 422
+        (imagePullSecret already exists).
+
+        if the imagePullSecret is not defined in the @configuration BUT the associated kubernetes object exists
+        this method will NOT override the contents of the Secret object with the contents of the request. It will
+        return 409 (imagePullSecret conflict with existing Secret object with the same name)
+
+        if the imagePullSecret is successfully created it will be available to use within a couple of minutes after
+        Kubernetes asynchronously refreshes the file whose contents are the @configuration.
+      operationId: put_image_pull_secret
+      parameters:
+        - name: payload
+          required: true
+          in: body
+          schema:
+            $ref: '#/definitions/imagepullsecret'
+      tags:
+        - image-pull-secrets
+    get:
+      responses:
+        '200':
+          description: Success
+          schema:
+            type: array
+            description: GET model for imagePullSecret with a given id
+            example:
+              - url-docker-registry1
+              - url-docker-registry2
+            items:
+              type: string
+              description: docker registry, e.g. res-drl-hpc-docker-local.artifactory.swg-devops.com
+              example: url-docker-registry
+        '404':
+          description: imagePullSecret not found
+        '500':
+          description: Internal error while retrieving imagePullSecret details
+      summary: Get imagePullSecret, returns a list of strings, each of which is a docker registry that the specified
+      description: imagePullSecret has pull access to
+      operationId: get_image_pull_secret
+      tags:
+        - image-pull-secrets
     post:
       responses:
         '200':
@@ -318,61 +373,6 @@ paths:
             $ref: '#/definitions/imagepullsecret'
       tags:
         - image-pull-secrets
-    get:
-      responses:
-        '200':
-          description: Success
-          schema:
-            type: array
-            description: GET model for imagePullSecret with a given id
-            example:
-              - url-docker-registry1
-              - url-docker-registry2
-            items:
-              type: string
-              description: docker registry, e.g. res-drl-hpc-docker-local.artifactory.swg-devops.com
-              example: url-docker-registry
-        '404':
-          description: imagePullSecret not found
-        '500':
-          description: Internal error while retrieving imagePullSecret details
-      summary: Get imagePullSecret, returns a list of strings, each of which is a docker registry that the specified
-      description: imagePullSecret has pull access to
-      operationId: get_image_pull_secret
-      tags:
-        - image-pull-secrets
-    put:
-      responses:
-        '200':
-          description: Success
-        '404':
-          description: imagePullSecret not found
-        '500':
-          description: Internal error while retrieving imagePullSecret details
-      summary: Update an existing imagePullSecret
-      description: |-
-        This method does not check whether the contents of the Secret object are correct. In the remainder of this
-        text @configuration IS the contents of the `config.json` key of the `consumable-computing-config` ConfigMap
-        (or the ConfigMap object that the environment variable `CONSUMABLE_COMPUTING_CONFIGMAP_NAME` points to)
-
-        if imagePullSecret is already defined in in the @configuration this method returns 422
-        (imagePullSecret already exists).
-
-        if the imagePullSecret is not defined in the @configuration BUT the associated kubernetes object exists
-        this method will NOT override the contents of the Secret object with the contents of the request. It will
-        return 409 (imagePullSecret conflict with existing Secret object with the same name)
-
-        if the imagePullSecret is successfully created it will be available to use within a couple of minutes after
-        Kubernetes asynchronously refreshes the file whose contents are the @configuration.
-      operationId: put_image_pull_secret
-      parameters:
-        - name: payload
-          required: true
-          in: body
-          schema:
-            $ref: '#/definitions/imagepullsecret'
-      tags:
-        - image-pull-secrets
   /instances/:
     get:
       responses:
@@ -399,13 +399,6 @@ paths:
         name: id
         required: true
         type: string
-    delete:
-      responses:
-        '404':
-          description: Instance not found
-      operationId: delete_instance
-      tags:
-        - instances
     get:
       responses:
         '404':
@@ -422,6 +415,13 @@ paths:
           type: boolean
           description: A boolean flag that allows converting NaN and infinite values to strings.
           default: false
+      tags:
+        - instances
+    delete:
+      responses:
+        '404':
+          description: Instance not found
+      operationId: delete_instance
       tags:
         - instances
   /instances/{id}/outputs:
@@ -543,19 +543,6 @@ paths:
       tags:
         - query
   /relationships/:
-    post:
-      responses:
-        '200':
-          description: Success
-      operationId: post_relationships
-      parameters:
-        - name: payload
-          required: true
-          in: body
-          schema:
-            $ref: '#/definitions/relationship'
-      tags:
-        - relationships
     get:
       responses:
         '200':
@@ -581,24 +568,37 @@ paths:
             - 'n'
       tags:
         - relationships
+    post:
+      responses:
+        '200':
+          description: Success
+      operationId: post_relationships
+      parameters:
+        - name: payload
+          required: true
+          in: body
+          schema:
+            $ref: '#/definitions/relationship'
+      tags:
+        - relationships
   /relationships/{identifier}:
     parameters:
       - name: identifier
         in: path
         required: true
         type: string
-    delete:
-      responses:
-        '200':
-          description: Success
-      operationId: delete_relationship
-      tags:
-        - relationships
     get:
       responses:
         '200':
           description: Success
       operationId: get_relationship
+      tags:
+        - relationships
+    delete:
+      responses:
+        '200':
+          description: Success
+      operationId: delete_relationship
       tags:
         - relationships
   /relationships/{identifier}/synthesize/{new_package_name}:
@@ -1155,18 +1155,24 @@ definitions:
         description: (VOLUME_TYPE) name of Secret object to mount, incompatible with other VOLUME_TYPE fields
     type: object
   file-content:
-    required:
-      - content
-      - filename
     properties:
       filename:
         type: string
-        description: Filename
+        description: Filename. Mutually exclusive with sourceFilename and targetFilename
         example: field.conf
+      sourceFilename:
+        type: string
+        description: path to the filename. Mutually exclusive with filename and content. If set, must also provide sourceFilename
+      targetFilename:
+        type: string
+        description: How to rename sourceFilename. Mutually exclusive with filename and content. If set, must also provide targetFilename
       content:
         type: string
-        description: Content of file
-        example: mole:capb,slampd,smlta conc:4.2,1.4,0.5 salt:2.8
+        description: Content of file. Mutually exclusive with sourceFilename and targetFilename
+        example: |-
+          mole:capb,slampd,smlta
+          conc:4.2,1.4,0.5
+          salt:2.8
     type: object
   container-resources:
     properties:


### PR DESCRIPTION
## Context

Resolves: https://github.com/st4sd/st4sd-runtime-service/issues/9

## Change list

- support renaming inputs and data files accessed via s3/datashim
- the entries in `inputs` and `data` fields of the experiment Start payload support `sourceFilename` and `targetFilename`. When set, st4sd-runtime-service configures elaunch.py (from st4sd-runtime-core) to process the `sourceFilename` as if it had the name `targetFile`

## Checklist

Ensure your PR meets the following requirements:

- [x] This PR is associated to one (or more) issues that are open
- [x] I have signed off my commits (using `git commit -s`)
- [x] I agree with the ST4SD Code of Conduct
